### PR TITLE
removed prefix "aurora-" from security group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ resource "aws_appautoscaling_policy" "autoscaling_read_replica_count" {
 
 resource "aws_security_group" "main" {
   count       = "${var.create_resources}"
-  name        = "aurora-${var.name}"
+  name        = "${var.name}"
   description = "For Aurora cluster ${var.name}"
   vpc_id      = "${var.vpc_id}"
   tags        = "${merge(var.tags, map("Name", "aurora-${var.name}"))}"


### PR DESCRIPTION
Most of the names of resources use ${var.name} except security group. Using same naming strategy for all resources may be more appropriate. 