### PR TITLE
Fixes a bug with upgrading engine version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,14 @@ resource "aws_rds_cluster_instance" "instance" {
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
   ca_cert_identifier              = var.ca_cert_identifier
   tags                            = var.tags
+  
+  # Updating engine version forces replacement of instances, and they shouldn't be replaced
+  # because cluster will update them if engine version is changed
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }  
 }
 
 resource "aws_rds_cluster_instance" "data_reader" {
@@ -97,6 +105,14 @@ resource "aws_rds_cluster_instance" "data_reader" {
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
   ca_cert_identifier              = var.ca_cert_identifier
   tags                            = merge(var.tags, var.data_reader_tags)
+  
+  # Updating engine version forces replacement of instances, and they shouldn't be replaced
+  # because cluster will update them if engine version is changed
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }  
 }
 
 resource "random_id" "snapshot_identifier" {


### PR DESCRIPTION
Recently we were encountering the described error here: https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/issues/118
when we were upgrading from `10.11` to `10.14`. It dropped the instances and then stopped right in the middle with a 400 - leaving everything in pieces behind :(.
I tried the fix locally by modifying the `terraform/apps/oma/.terraform/eu01/stg02-de/modules/oma.db/main.tf` file according to the changes and applying against `eu01-stg02-de-oma`. First run with `apply_immediately: false` showed and performed changes, but actually nothing was done. There was no schedule either. Doing the same with `true` again, finally upgraded successfully.